### PR TITLE
Add static files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 recursive-include wagtail_guide/templates *
-
+recursive-include wagtail_guide/static *
 


### PR DESCRIPTION
The current package on pypi is missing the CSS files, because they are not referenced in the manifest.

This patch tweaks the manifest to ensure that the static assets are included in the package.