### PR TITLE
Update deprecated import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@
 Installs the Wagtail Guide plugin.
 """
 
-from setuptools import setup, find_packages
 from os import path
+
+from setuptools import find_packages, setup
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
@@ -25,4 +26,5 @@ setup(name='wagtail_guide',
       include_package_data=True,
       install_requires=[
           'wagtail>=2.4',
+          'django>=2.1',
       ])

--- a/wagtail_guide/wagtail_hooks.py
+++ b/wagtail_guide/wagtail_hooks.py
@@ -1,5 +1,5 @@
 from django.conf.urls import url
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
I spotted #8 _after_ doing/testing this.

Either would appear to be valid I think, though I would suggest that as this package specifies minimum wagtail version of 2.4, which [supports Django 2.0/2.1](https://docs.wagtail.io/en/v2.4/releases/upgrading.html#compatible-django-python-versions) then maybe could choose to avoid testing versions when importing and just specify a minimum django version (2.1) for the package. 

This PR provided for comparison, personally I would be happy with either approach.