### PR TITLE
Update for wagtail 2.10 - remove request.site reference

### DIFF
--- a/wagtail_guide/views.py
+++ b/wagtail_guide/views.py
@@ -1,4 +1,6 @@
 from django.shortcuts import render
+from wagtail.core.models import Site
+
 from .models import EditorGuide
 
 
@@ -6,8 +8,9 @@ def index(request):
     # There should only ever be one instance of the guide
     # But we need to check the site incase there is a 'per' site guide
     # On a multisite setup
-    content = EditorGuide.objects.all().filter(site=request.site).first()
-
+    content = EditorGuide.objects.all().filter(
+        site=Site.find_for_request(request)
+    ).first()
 
     # Send a boolean to populate a menu if there are more than
     # one 'heading' block type.


### PR DESCRIPTION
https://docs.wagtail.io/en/latest/releases/2.9.html#upgrade-considerations

As of wagtail 2.10 request.site is no longer available. The suggested replacement appears to have been available way back, so shouldn't cause backwards compatibility issues.