### PR TITLE
Wagtail 5.x upgrades

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,10 @@ jobs:
         include:
           - python: 3.9
             wagtail: wagtail>=4.1,<5.1
+          - python: 3.9
+            wagtail: wagtail>=4.2,<5.0
+          - python: 3.9
+            wagtail: wagtail>=5.0,<5.1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,22 +42,47 @@ jobs:
             django: django>=3.2,<4.0
             wagtail: wagtail>=4.1,<4.2
           - python: "3.9"
-            django: django>=4.2,<4.3
+            django: django>=3.2,<4.0
             wagtail: wagtail>=5.1,<5.2
           - python: "3.9"
-            django: django>=4.2,<4.3
+            django: django>=3.2,<4.0
             wagtail: wagtail>=5.2,<5.3
-
+          - python: "3.9"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=4.1,<4.2
+          - python: "3.9"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=5.1,<5.2
+          - python: "3.9"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=5.2,<5.3
           - python: "3.10"
             django: django>=3.2,<4.0
             wagtail: wagtail>=4.1,<4.2
           - python: "3.10"
-            django: django>=4.2,<4.3
+            django: django>=3.2,<4.0
             wagtail: wagtail>=5.1,<5.2
           - python: "3.10"
-            django: django>=4.2,<4.3
+            django: django>=3.2,<4.0
             wagtail: wagtail>=5.2,<5.3
-
+          - python: "3.10"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=4.1,<4.2
+          - python: "3.10"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=5.1,<5.2
+          - python: "3.10"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=5.2,<5.3
+          - python: "3.11"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=4.1,<4.2
+          - python: "3.11"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=5.1,<5.2
+          - python: "3.11"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=5.2,<5.3
           - python: "3.11"
             django: django>=4.2,<4.3
             wagtail: wagtail>=5.1,<5.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,37 +42,28 @@ jobs:
             django: django>=3.2,<4.0
             wagtail: wagtail>=4.1,<4.2
           - python: "3.9"
-            django: django>=4.1,<4.2
-            wagtail: wagtail>=4.2,<5.0
-          - python: "3.9"
-            django: django>=4.2,<4.3
-            wagtail: wagtail>=5.0,<5.1
-          - python: "3.9"
             django: django>=4.2,<4.3
             wagtail: wagtail>=5.1,<5.2
+          - python: "3.9"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.2,<5.3
 
           - python: "3.10"
             django: django>=3.2,<4.0
             wagtail: wagtail>=4.1,<4.2
           - python: "3.10"
-            django: django>=4.1,<4.2
-            wagtail: wagtail>=4.2,<5.0
-          - python: "3.10"
-            django: django>=4.2,<4.3
-            wagtail: wagtail>=5.0,<5.1
-          - python: "3.10"
             django: django>=4.2,<4.3
             wagtail: wagtail>=5.1,<5.2
+          - python: "3.10"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.2,<5.3
 
           - python: "3.11"
-            django: django>=4.1,<4.2
-            wagtail: wagtail>=4.2,<5.0
-          - python: "3.11"
-            django: django>=4.2,<4.3
-            wagtail: wagtail>=5.0,<5.1
-          - python: "3.11"
             django: django>=4.2,<4.3
             wagtail: wagtail>=5.1,<5.2
+          - python: "3.11"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.2,<5.3
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,9 @@ on:
     branches: [master]
 
 # Current configuration:
-# - python 3.9, wagtail 4.1
+# - python 3.9, django 3.2, wagtail 4.1
+# - python 3.9, django 4.1, wagtail 4.2
+# - python 3.9, django 4.2, wagtail 5.0
 
 jobs:
   lint:
@@ -36,12 +38,41 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: 3.9
-            wagtail: wagtail>=4.1,<5.1
-          - python: 3.9
+          - python: "3.9"
+            django: django>=3.2,<4.0
+            wagtail: wagtail>=4.1,<4.2
+          - python: "3.9"
+            django: django>=4.1,<4.2
             wagtail: wagtail>=4.2,<5.0
-          - python: 3.9
+          - python: "3.9"
+            django: django>=4.2,<4.3
             wagtail: wagtail>=5.0,<5.1
+          - python: "3.9"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.1,<5.2
+
+          - python: "3.10"
+            django: django>=3.2,<4.0
+            wagtail: wagtail>=4.1,<4.2
+          - python: "3.10"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=4.2,<5.0
+          - python: "3.10"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.0,<5.1
+          - python: "3.10"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.1,<5.2
+
+          - python: "3.11"
+            django: django>=4.1,<4.2
+            wagtail: wagtail>=4.2,<5.0
+          - python: "3.11"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.0,<5.1
+          - python: "3.11"
+            django: django>=4.2,<4.3
+            wagtail: wagtail>=5.1,<5.2
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add support for Wagtail v5.0+
+- Add Wagtail v5.2 to test matrix
+
 ## [2.0.1] (2023-07-27)
 
 - Improve contribution documentation

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "wagtail>=4.1",
+        "Django>=3.2",
     ],
 )

--- a/wagtail_guide/tests/settings.py
+++ b/wagtail_guide/tests/settings.py
@@ -79,3 +79,5 @@ WAGTAIL_GUIDE_SETTINGS = {
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+STATIC_URL = "/static/"

--- a/wagtail_guide/tests/settings.py
+++ b/wagtail_guide/tests/settings.py
@@ -77,3 +77,5 @@ WAGTAIL_GUIDE_SETTINGS = {
     "WAGTAIL_GUIDE_MENU_LABEL": "WG guide menu label",
     "HIDE_WAGTAIL_CORE_EDITOR_GUIDE": True,
 }
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/wagtail_guide/wagtail_hooks.py
+++ b/wagtail_guide/wagtail_hooks.py
@@ -2,7 +2,7 @@ from django.templatetags.static import static
 from django.urls import re_path, reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
-from wagtail import hooks
+from wagtail import hooks, VERSION as WAGTAIL_VERSION
 from wagtail.admin.menu import MenuItem
 
 from . import views
@@ -20,22 +20,28 @@ if wagtail_guide_settings.ADD_WAGTAIL_GUIDE_TO_HELP_MENU:
 
     @hooks.register("register_help_menu_item")
     def register_editor_guide_menu_item():
+        key = "classname" if WAGTAIL_VERSION >= (5, 2) else "classnames"
+        kwargs = {key: "icon icon-help"}
+
         return MenuItem(
             _(wagtail_guide_settings.WAGTAIL_GUIDE_MENU_LABEL),
             reverse("wagtaileditorguide"),
-            classnames="icon icon-help",
             order=1000,
+            **kwargs,
         )
 
 else:
 
     @hooks.register("register_admin_menu_item")
     def register_editor_guide_menu_item():
+        key = "classname" if WAGTAIL_VERSION >= (5, 2) else "classnames"
+        kwargs = {key: "icon icon-help"}
+
         return MenuItem(
             _(wagtail_guide_settings.WAGTAIL_GUIDE_MENU_LABEL),
             reverse("wagtaileditorguide"),
-            classnames="icon icon-help",
             order=1000,
+            **kwargs,
         )
 
 

--- a/wagtail_guide/wagtail_hooks.py
+++ b/wagtail_guide/wagtail_hooks.py
@@ -2,7 +2,8 @@ from django.templatetags.static import static
 from django.urls import re_path, reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
-from wagtail import hooks, VERSION as WAGTAIL_VERSION
+from wagtail import VERSION as WAGTAIL_VERSION
+from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 
 from . import views


### PR DESCRIPTION
## Wagtail 5.1 ([See release notes](https://docs.wagtail.org/en/stable/releases/5.1.html))

The changes here probably don't need a new release and the package should continue to work OK on Wagtail v5.1

## Wagtail 5.2 ([See release notes](https://docs.wagtail.org/en/stable/releases/5.2.html))

### Changes:
- [Adoption of classname convention for MenuItem related classes and hooks](https://docs.wagtail.org/en/stable/releases/5.2.html#adoption-of-classname-convention-for-menuitem-related-classes-and-hooks)